### PR TITLE
Sqlite support

### DIFF
--- a/src/dbsync.cpp
+++ b/src/dbsync.cpp
@@ -39,7 +39,7 @@ using std::vector;
 
 struct CommandArguments {
 	bool validate = true;
-	int validateLength = 30;
+	int validateLength = 100;
 };
 
 #ifndef VERSIONNUMBER

--- a/src/sago/DbSyncDbMySql.cpp
+++ b/src/sago/DbSyncDbMySql.cpp
@@ -267,7 +267,7 @@ namespace sago {
 			return ret;
 		}
 
-		void DbSyncDbMySql::CreateTable(const sago::database::DbTable& t) {
+		void DbSyncDbMySql::CreateTable(const sago::database::DbTable& t, const std::vector<DbForeignKeyConstraint>& foreign_keys) {
 			if (!TableExists(t.tablename)) {
 				std::string create_table_sql = "CREATE TABLE " + schema + "." + t.tablename + " ( " + this->sago_id + " INT(20) NOT NULL AUTO_INCREMENT UNIQUE )";
 				for (const sago::database::DbColumn& c : t.columns) {

--- a/src/sago/DbSyncDbMySql.hpp
+++ b/src/sago/DbSyncDbMySql.hpp
@@ -56,7 +56,7 @@ namespace sago {
 			virtual sago::database::DbUniqueConstraint GetUniqueConstraint(const std::string& tablename, const std::string& name) override;
 			virtual sago::database::DbForeignKeyConstraint GetForeignKeyConstraint(const std::string& tablename, const std::string& name) override;
 
-			virtual void CreateTable(const sago::database::DbTable& t) override;
+			virtual void CreateTable(const sago::database::DbTable& t, const std::vector<DbForeignKeyConstraint>& foreign_keys) override;
 			virtual void CreateColumn(const std::string& tablename, const sago::database::DbColumn& c) override;
 			virtual void CreateUniqueConstraint(const sago::database::DbUniqueConstraint& c) override;
 			virtual void CreateForeignKeyConstraint(const sago::database::DbForeignKeyConstraint& c) override;

--- a/src/sago/DbSyncDbPostgres.cpp
+++ b/src/sago/DbSyncDbPostgres.cpp
@@ -308,7 +308,7 @@ namespace sago {
 			return ret;
 		}
 
-		void DbSyncDbPostgres::CreateTable(const sago::database::DbTable& t) {
+		void DbSyncDbPostgres::CreateTable(const sago::database::DbTable& t, const std::vector<DbForeignKeyConstraint>& foreign_keys) {
 			if (!TableExists(t.tablename)) {
 				std::string create_table_sql = "CREATE TABLE " + t.tablename + " ( " + this->sago_id + " INT(20) NOT NULL AUTO_INCREMENT UNIQUE )";
 				for (const sago::database::DbColumn& c : t.columns) {

--- a/src/sago/DbSyncDbPostgres.hpp
+++ b/src/sago/DbSyncDbPostgres.hpp
@@ -56,7 +56,7 @@ namespace sago {
 			virtual sago::database::DbUniqueConstraint GetUniqueConstraint(const std::string& tablename, const std::string& name) override;
 			virtual sago::database::DbForeignKeyConstraint GetForeignKeyConstraint(const std::string& tablename, const std::string& name) override;
 
-			virtual void CreateTable(const sago::database::DbTable& t) override;
+			virtual void CreateTable(const sago::database::DbTable& t, const std::vector<DbForeignKeyConstraint>& foreign_keys) override;
 			virtual void CreateColumn(const std::string& tablename, const sago::database::DbColumn& c) override;
 			virtual void CreateUniqueConstraint(const sago::database::DbUniqueConstraint& c) override;
 			virtual void CreateForeignKeyConstraint(const sago::database::DbForeignKeyConstraint& c) override;

--- a/src/sago/DbSyncDbSqlite.cpp
+++ b/src/sago/DbSyncDbSqlite.cpp
@@ -63,7 +63,7 @@ namespace sago {
 		}
 
 		bool DbSyncDbSqlite::ForeignKeyExists(const std::string& tablename, const std::string& name) {
-			cppdb::result res = *sql << "PRAGMA foreign_key_list(" << tablename << ");";
+			cppdb::result res = *sql << "PRAGMA foreign_key_list(" + tablename + ");";
 			while (res.next()) {
 				std::string indexname;
 				res >> indexname;
@@ -79,19 +79,28 @@ namespace sago {
 		}
 
 		bool DbSyncDbSqlite::ColumnExists(const std::string& tablename, const std::string& columnname) {
-			cppdb::result res = *sql << "PRAGMA table_info(" << tablename << ");";
-			while (res.next()) {
-				std::string name;
-				res >> name;
-				if (name == columnname) {
-					return true;
+			try {
+				cppdb::result res = *sql << "PRAGMA table_info(" + tablename + ")";
+				while (res.next()) {
+					std::string name;
+					name = res.get<std::string>("name");
+					if (name == columnname) {
+						return true;
+					}
 				}
+				return false;
+			} catch (std::exception& e) {
+				throw DbException(e.what(), "DbSyncDbSqlite::ColumnExists failed", columnname, tablename);
 			}
-			return false;
 		}
 
 		void DbSyncDbSqlite::CreateTable(const sago::database::DbTable& t) {
 			if (TableExists(t.tablename)) {
+				for (const sago::database::DbColumn& c : t.columns) {
+					if (!ColumnExists(t.tablename, c.name)) {
+						CreateColumn(t.tablename, c);
+					}
+				}
 				return;
 			}
 			std::string sqlStr = "CREATE TABLE " + t.tablename + " (";
@@ -142,8 +151,66 @@ namespace sago {
 			}
 		}
 
+		void DbSyncDbSqlite::CreateColumn(const std::string& tablename, const sago::database::DbColumn& c) {
+			if (ColumnExists(tablename, c.name)) {
+				return;
+			}
+			std::string sqlStr = "ALTER TABLE " + tablename + " ADD COLUMN " + c.name + " ";
+			switch (c.type) {
+			case SagoDbType::TEXT:
+				sqlStr += "TEXT";
+				break;
+			case SagoDbType::NUMBER:
+				sqlStr += "DOUBLE";
+				break;
+			case SagoDbType::DATE:
+				sqlStr += "DATE";
+				break;
+			case SagoDbType::BLOB:
+				sqlStr += "BLOB";
+				break;
+			case SagoDbType::CLOB:
+				sqlStr += "CLOB";
+				break;
+			case SagoDbType::FLOAT:
+				sqlStr += "FLOAT";
+				break;
+			case SagoDbType::DOUBLE:
+				sqlStr += "DOUBLE";
+				break;
+			case SagoDbType::TIMESTAMP:
+				sqlStr += "TIMESTAMP";
+				break;
+			case SagoDbType::NONE:
+				throw DbException("DbSyncDbSqlite::CreateColumn", "Column type is NONE", c.name, tablename);
+			}
+			sqlStr += ";";
+			std::cout << sqlStr << std::endl;
+			cppdb::statement st = *sql << sqlStr;
+			try {
+				st.exec();
+			} catch (std::exception& e) {
+				std::cerr << "Failed: " << sqlStr << "\n";
+				throw;
+			}
+		}
+
+		static bool str_starts_with(const std::string& str, const std::string& prefix) {
+			if (str.length() < prefix.length()) {
+				return false;
+			}
+			return str.substr(0, prefix.length()) == prefix;
+		}
+
 		void DbSyncDbSqlite::CreateUniqueConstraint(const sago::database::DbUniqueConstraint& c) {
-			std::string sqlStr = "CREATE UNIQUE INDEX " + c.name + " ON " + c.tablename + " (";
+			std::string indexName = c.name;
+			if ( !str_starts_with(indexName, c.tablename + "_") ){
+				indexName = c.tablename + "_" + indexName;
+			}
+			if (UniqueConstraintExists(c.tablename, indexName)) {
+				return;
+			}
+			std::string sqlStr = "CREATE UNIQUE INDEX " + indexName + " ON " + c.tablename + " (";
 			bool first = true;
 			for (const auto& col : c.columns) {
 				if (!first) {

--- a/src/sago/DbSyncDbSqlite.hpp
+++ b/src/sago/DbSyncDbSqlite.hpp
@@ -44,9 +44,10 @@ namespace sago {
 			virtual bool ForeignKeyExists(const std::string& tablename, const std::string& name) override;
 			virtual bool SchemaExists(const std::string& schemaname) override;
 
-			virtual void CreateTable(const sago::database::DbTable& t) override;
+			virtual void CreateTable(const sago::database::DbTable& t, const std::vector<DbForeignKeyConstraint>& foreign_keys) override;
 			virtual void CreateColumn(const std::string& tablename, const sago::database::DbColumn& c) override;
 			virtual void CreateUniqueConstraint(const sago::database::DbUniqueConstraint& c) override;
+			virtual void CreateForeignKeyConstraint(const sago::database::DbForeignKeyConstraint& c) override;
 		private:
 			std::shared_ptr<cppdb::session> sql;
 		};

--- a/src/sago/DbSyncDbSqlite.hpp
+++ b/src/sago/DbSyncDbSqlite.hpp
@@ -45,7 +45,7 @@ namespace sago {
 			virtual bool SchemaExists(const std::string& schemaname) override;
 
 			virtual void CreateTable(const sago::database::DbTable& t) override;
-
+			virtual void CreateColumn(const std::string& tablename, const sago::database::DbColumn& c) override;
 			virtual void CreateUniqueConstraint(const sago::database::DbUniqueConstraint& c) override;
 		private:
 			std::shared_ptr<cppdb::session> sql;

--- a/src/sago/DbSyncDbSqlite.hpp
+++ b/src/sago/DbSyncDbSqlite.hpp
@@ -39,6 +39,14 @@ namespace sago {
 			virtual ~DbSyncDbSqlite();
 
 			virtual bool TableExists(const std::string& tablename) override;
+			virtual bool ColumnExists(const std::string& tablename, const std::string& columnname) override;
+			virtual bool UniqueConstraintExists(const std::string& tablename, const std::string& name) override;
+			virtual bool ForeignKeyExists(const std::string& tablename, const std::string& name) override;
+			virtual bool SchemaExists(const std::string& schemaname) override;
+
+			virtual void CreateTable(const sago::database::DbTable& t) override;
+
+			virtual void CreateUniqueConstraint(const sago::database::DbUniqueConstraint& c) override;
 		private:
 			std::shared_ptr<cppdb::session> sql;
 		};

--- a/src/sago/DbSyncValidator.hpp
+++ b/src/sago/DbSyncValidator.hpp
@@ -49,7 +49,7 @@ namespace sago {
 			bool checkNamesCase = true;
 			bool checkNamesChars = true;
 			bool checkNamesLength = false;
-			int nameMaxLength = 30;
+			int nameMaxLength = 100;
 		private:
 			std::string schemaNameBeingValidated = "";
 			void ValidateDuplicates();

--- a/src/sago/dbsync_db.cpp
+++ b/src/sago/dbsync_db.cpp
@@ -31,7 +31,7 @@ namespace sago {
 
 		void ApplyDataModel(const DbDatabaseModel& model, DbSyncDb& db) {
 			for (const DbTable& t : model.tables) {
-				db.CreateTable(t);
+				db.CreateTable(t, model.foreign_keys);
 			}
 			for (const DbUniqueConstraint& uc : model.unique_constraints) {
 				if (!db.UniqueConstraintExists(uc.tablename, uc.name)) {

--- a/src/sago/dbsync_db.hpp
+++ b/src/sago/dbsync_db.hpp
@@ -87,7 +87,12 @@ namespace sago {
 				return DbForeignKeyConstraint();
 			}
 
-			virtual void CreateTable(const DbTable& t) {
+			/**
+			 * Create a table in the database
+			 * @param t The table to create
+			 * @param foreign_keys All the foreign keys in the database. The list might contain foreign keys that are not for this table.
+			*/
+			virtual void CreateTable(const DbTable& t, const std::vector<DbForeignKeyConstraint>& foreign_keys) {
 				throw DbException("Not implemented", "CreateTable not implemented", t.tablename, "");
 			}
 

--- a/src/sago/dbsync_db.hpp
+++ b/src/sago/dbsync_db.hpp
@@ -88,15 +88,19 @@ namespace sago {
 			}
 
 			virtual void CreateTable(const DbTable& t) {
+				throw DbException("Not implemented", "CreateTable not implemented", t.tablename, "");
 			}
 
 			virtual void CreateColumn(const std::string& tablename, const DbColumn& c) {
+				throw DbException("Not implemented", "CreateColumn not implemented", tablename, "");
 			}
 
 			virtual void CreateUniqueConstraint(const DbUniqueConstraint& c) {
+				throw DbException("Not implemented", "CreateUniqueConstraint not implemented", c.tablename, "");
 			}
 
 			virtual void CreateForeignKeyConstraint(const DbForeignKeyConstraint& c) {
+				throw DbException("Not implemented", "CreateForeignKeyConstraint not implemented", c.tablename, "");
 			}
 
 			virtual ~DbSyncDb() {


### PR DESCRIPTION
Working SQLite.

Basic functionality. Foreign keys cannot be added after table creation and cannot be named.